### PR TITLE
Build universal binary for mac.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,7 @@ stages:
           - script: |
               mkdir $(BUILD_DIRECTORY)
               cd $(BUILD_DIRECTORY)
-              cmake -DCMAKE_INSTALL_PREFIX="$(INSTALL_DIRECTORY)/$(BuildType)" -DCMAKE_BUILD_TYPE=$(BuildType) -DBUILD_LLVM=$(BUILD_LLVM) ..
+              cmake -DCMAKE_INSTALL_PREFIX="$(INSTALL_DIRECTORY)/$(BuildType)" -DCMAKE_BUILD_TYPE=$(BuildType) -DBUILD_LLVM=$(BUILD_LLVM) -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" ..
             displayName: ConfigureCommand
           - script: |
               cd $(BUILD_DIRECTORY)


### PR DESCRIPTION
Hopefully, this will let us build universal binaries in Azure on the mac for roadrunner.