### PR TITLE
upgrade-GitHub-hosted-macOS-x86_64-to-macOS12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - name: macos-11-release
+          - name: macos-12-release
             os_type: macos
-            os_name: macos-11
+            os_name: macos-12
             build_type: Release
-          - name: macos-11-debug
+          - name: macos-12-debug
             os_type: macos
-            os_name: macos-11
+            os_name: macos-12
             build_type: Debug
           - name: macos-14-release
             os_type: macos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@master
+        uses: seanmiddleditch/gha-setup-ninja@v4
 
       - name: Get Host Architecture
         shell: bash


### PR DESCRIPTION
macOS virtual machine for x86_64 arch is updated to macOS 12 as macOS 11 is now deprecated on GitHub server