### PR TITLE
Remove LLVM from the list.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "third_party/poco"]
 	path = third_party/poco
 	url = https://github.com/sys-bio/poco.git
-[submodule "third_party/llvm-13.x"]
-	path = third_party/llvm-13.x
-	url = https://github.com/sys-bio/llvm-13.x.git
 [submodule "third_party/rr-libstruct"]
 	path = third_party/rr-libstruct
 	url = https://github.com/sys-bio/rr-libstruct.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,6 @@ endif()
 #
 
 option(BUILD_PACKAGING "Build the packaging" OFF)
-option(BUILD_LLVM "build llvm" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -214,49 +213,6 @@ mark_as_advanced(
         ENABLE_TESTS
 )
 
-# LLVM options - turn as much as we can off
-
-# we need tools on for llvm-config, which is used in FindLLVM.
-# ... or we could hard code the options that we extract from llvm-config
-# and save some built time on llvm. The downside of this idea is reduced flexibility
-# should we choose to update llvm.
-#option(LLVM_INCLUDE_TOOLS "llvm option \"LLVM_INCLUDE_TOOLS\"" ON)
-#option(LLVM_BUILD_TOOLS "llvm option \"LLVM_BUILD_TOOLS\"" ON)
-#option(LLVM_INCLUDE_UTILS "llvm option \"LLVM_INCLUDE_UTILS\"" OFF)
-#option(LLVM_BUILD_UTILS "llvm option \"LLVM_BUILD_UTILS\"" OFF)
-#option(LLVM_INCLUDE_RUNTIMES "llvm option \"LLVM_INCLUDE_RUNTIMES\"" OFF)
-#option(LLVM_BUILD_RUNTIMES "llvm option \"LLVM_BUILD_RUNTIMES\"" OFF)
-#option(LLVM_BUILD_RUNTIME "llvm option \"LLVM_BUILD_RUNTIME\"" OFF)
-#option(LLVM_INCLUDE_TESTS "llvm option \"LLVM_INCLUDE_TESTS\"" OFF)
-#option(LLVM_BUILD_TESTS "llvm option \"LLVM_BUILD_TESTS\"" OFF)
-#option(LLVM_INCLUDE_TESTS "llvm option \"LLVM_INCLUDE_TESTS\"" OFF)
-#option(LLVM_BUILD_EXAMPLES "llvm option \"LLVM_BUILD_EXAMPLES\"" OFF)
-#option(LLVM_INCLUDE_EXAMPLES "llvm option \"LLVM_INCLUDE_EXAMPLES\"" OFF)
-#option(LLVM_BUILD_DOCS "llvm option \"LLVM_BUILD_DOCS\"" OFF)
-#option(LLVM_INCLUDE_DOCS "llvm option \"LLVM_INCLUDE_DOCS\"" OFF)
-#option(LLVM_ENABLE_DOXYGEN "llvm option \"LLVM_ENABLE_DOXYGEN\"" OFF)
-#option(LLVM_ENABLE_SPHINX "llvm option \"LLVM_ENABLE_SPHINX\"" OFF)
-#option(LLVM_ENABLE_OCAMLDOC "llvm option \"LLVM_ENABLE_OCAMLDOC\"" OFF)
-#
-#mark_as_advanced(
-#        LLVM_INCLUDE_TOOLS
-#        LLVM_BUILD_TOOLS
-#        LLVM_INCLUDE_UTILS
-#        LLVM_BUILD_UTILS
-#        LLVM_INCLUDE_RUNTIMES
-#        LLVM_BUILD_RUNTIMES
-#        LLVM_BUILD_RUNTIME
-#        LLVM_INCLUDE_TESTS
-#        LLVM_BUILD_TESTS
-#        LLVM_INCLUDE_TESTS
-#        LLVM_BUILD_EXAMPLES
-#        LLVM_INCLUDE_EXAMPLES
-#        LLVM_BUILD_DOCS
-#        LLVM_INCLUDE_DOCS
-#        LLVM_ENABLE_DOXYGEN
-#        LLVM_ENABLE_SPHINX
-#        LLVM_ENABLE_OCAMLDOC
-#)
 message(STATUS "BUILD_CVODE 1: ${BUILD_CVODE}")
 add_subdirectory(third_party)
 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -7,7 +7,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-DCMAKE_INSTALL_PREFIX=..\\install-msvc-release -DBUILD_LLVM=ON",
+      "cmakeCommandArgs": "-DCMAKE_INSTALL_PREFIX=..\\install-msvc-release",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "variables": []

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,5 +1,3 @@
-#set(BUILD_LLVM ON )
-
 # We need a list of targets to ensure the install target defined below
 # gets built last
 set(

--- a/roadrunner_deps_build.py
+++ b/roadrunner_deps_build.py
@@ -3,11 +3,10 @@ Build the libroadrunner-deps  roadrunner dependency package.
 
 Usage:
 
-    python roadrunner_deps_build.py "/full/path/to/where/you/want/to/install/the/roadrunner/dependencies/" [--with-llvm] [--build-type=[Release|Debug]]
+    python roadrunner_deps_build.py "/full/path/to/where/you/want/to/install/the/roadrunner/dependencies/" [--build-type=[Release|Debug]]
 
 Options:
 
-    --with-llvm: turns on building llvm along with the other dependencies
     --build-type=value: where value is a valid cmake build type. Defaults to Release
 """
 
@@ -17,8 +16,6 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("install_prefix", help="the cmake_install_prefix variable")
-parser.add_argument("--with_llvm", help="Download and build llvm-6.x (takes longer)", default=False,
-                    action="store_true")
 parser.add_argument("--build-type", type=str, help="the cmake_build_type variable", default="Release")
 args = parser.parse_args()
 
@@ -54,21 +51,12 @@ os.chdir(LIBROADRUNNER_DEPS_BUILD_DIR)
 
 
 # cmake command
-if (args.with_llvm):
-    do_check_call([
-        "cmake",
-        f"-DCMAKE_INSTALL_PREFIX={args.install_prefix}",
-        f"CMAKE_BUILD_TYPE={args.build_type}",
-        "-DBUILD_LLVM=ON",
-        LIBROADRUNNER_DEPS_DIR
-    ])
-else:
-    do_check_call([
-        "cmake",
-        f"-DCMAKE_INSTALL_PREFIX={args.install_prefix}",
-        f"CMAKE_BUILD_TYPE={args.build_type}",
-        LIBROADRUNNER_DEPS_DIR
-    ])
+do_check_call([
+    "cmake",
+    f"-DCMAKE_INSTALL_PREFIX={args.install_prefix}",
+    f"CMAKE_BUILD_TYPE={args.build_type}",
+    LIBROADRUNNER_DEPS_DIR
+])
 
 # build and install command
 do_check_call(["cmake" "--build", f"{LIBROADRUNNER_DEPS_BUILD_DIR}", "--target", "install", "-j", 12])

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -195,22 +195,6 @@ set(SBMLNETWORK_TARGET_ID "sbmlnetwork-static")
 add_dependencies(${SBMLNETWORK_TARGET_ID} "${LIBSBML_TARGET_ID}" expat zlibstatic)
 
 
-if (${BUILD_LLVM})
-    message(STATUS "Adding llvm-13.x/llvm as subdirectory")
-    add_subdirectory(llvm-13.x/llvm)
-else ()
-    message(WARNING "Not building LLVM (-DBUILD_LLVM=ON). LLVM is a required dependency of roadrunner. Not \
-marking LLVM for building means that you must already have a built copy of llvm-13.x. If this is in a \
-system directory (like \"/usr/local\" or \"C:\\Program Files\") this will be found automatically \
-when you run the cmake command for the main roadrunner repository. If installed in a \
-non-standard location you will need to provide the full path to the llvm-13.x install directory when running \
-the cmake command for roadrunner i.e.
-    -DLLVM_INSTALL_PREFIX=\"/full/path/to/llvm\"
-If you do not already have llvm-13.x, please re-run cmake with
-    -DBUILD_LLVM=ON
-")
-endif ()
-
 
 
 #From https://stackoverflow.com/questions/37434946/how-do-i-iterate-over-all-cmake-targets-programmatically


### PR DESCRIPTION
It was huge, and we didn't actually build it here anyway; we build it directly in its own cloned repository.